### PR TITLE
Label cleanup

### DIFF
--- a/demo/esri-ds2022/src/components/clustering/clustering.tsx
+++ b/demo/esri-ds2022/src/components/clustering/clustering.tsx
@@ -215,6 +215,7 @@ export class Clustering {
               mapView={this.mapView}
               displayType={DisplayType.cluster}
               labelPanel={this.labelPanel}
+              onLabelUpdated={() => this.internalFeatureReductionUpdated.emit()}
             />
           </calcite-panel>
         ) : null}

--- a/demo/esri-ds2022/src/components/label/label-content-style/label-content-style.css
+++ b/demo/esri-ds2022/src/components/label/label-content-style/label-content-style.css
@@ -1,0 +1,3 @@
+.popover {
+  z-index: 100;
+}

--- a/demo/esri-ds2022/src/components/label/label-content-style/label-content-style.tsx
+++ b/demo/esri-ds2022/src/components/label/label-content-style/label-content-style.tsx
@@ -5,6 +5,7 @@ import { Component, h, Prop, Event, EventEmitter, Listen, VNode } from "@stencil
 /** @internal **/
 @Component({
   tag: "esri-ds2022-label-content-style",
+  styleUrl: "label-content-style.css",
   shadow: true
 })
 export class LabelContentStyle {
@@ -26,6 +27,26 @@ export class LabelContentStyle {
     this.closeLabelPopovers.emit();
   }
 
+  fontSizeSelectionChange = (event: CustomEvent): void => {
+    (this.labelClass.symbol as __esri.TextSymbol).font.size = Number(event.detail.value) * 0.75;
+    this.labelContentStyleChanges.emit();
+  };
+
+  colorChange = (event: any): void => {
+    this.labelClass.symbol.color = event.target?.value;
+    this.labelContentStyleChanges.emit();
+  };
+
+  OffsetXChange = (event: CustomEvent): void => {
+    (this.labelClass.symbol as __esri.TextSymbol).xoffset = Number(event.detail.value);
+    this.labelContentStyleChanges.emit();
+  };
+
+  OffsetYChange = (event: CustomEvent): void => {
+    (this.labelClass.symbol as __esri.TextSymbol).yoffset = Number(event.detail.value);
+    this.labelContentStyleChanges.emit();
+  };
+
   render(): VNode {
     // change font size
     const fontSizeSelection = (
@@ -37,12 +58,7 @@ export class LabelContentStyle {
           min={5}
           max={125}
           value={`${(this.labelClass.symbol as __esri.TextSymbol).font.size / 0.75 || 0}`}
-          // todo: move into class function
-          onCalciteInputInput={(event: CustomEvent): void => {
-            (this.labelClass.symbol as __esri.TextSymbol).font.size =
-              Number(event.detail.value) * 0.75;
-            this.labelContentStyleChanges.emit();
-          }}
+          onCalciteInputInput={this.fontSizeSelectionChange}
         />
       </calcite-label>
     );
@@ -56,11 +72,7 @@ export class LabelContentStyle {
           hideSaved={true}
           scale="m"
           value={this.labelClass.symbol.color?.toHex() || "#ffffff"}
-          // todo: move into class function
-          onCalciteColorPickerInput={(event: any): void => {
-            this.labelClass.symbol.color = event.target?.value;
-            this.labelContentStyleChanges.emit();
-          }}
+          onCalciteColorPickerInput={this.colorChange}
         />
       </calcite-label>
     );
@@ -77,11 +89,7 @@ export class LabelContentStyle {
             value={`${(this.labelClass.symbol as __esri.TextSymbol).xoffset || 0}`}
             min={-20}
             max={20}
-            // todo: move into class function
-            onCalciteInputInput={(event: CustomEvent): void => {
-              (this.labelClass.symbol as __esri.TextSymbol).xoffset = Number(event.detail.value);
-              this.labelContentStyleChanges.emit();
-            }}
+            onCalciteInputInput={this.OffsetXChange}
           ></calcite-input>
         </calcite-label>
         <calcite-label scale="s">
@@ -93,11 +101,7 @@ export class LabelContentStyle {
             value={`${(this.labelClass.symbol as __esri.TextSymbol).yoffset || 0}`}
             min={-20}
             max={20}
-            // todo: move into class function
-            onCalciteInputInput={(event: CustomEvent): void => {
-              (this.labelClass.symbol as __esri.TextSymbol).yoffset = Number(event.detail.value);
-              this.labelContentStyleChanges.emit();
-            }}
+            onCalciteInputInput={this.OffsetYChange}
           ></calcite-input>
         </calcite-label>
       </div>
@@ -112,10 +116,7 @@ export class LabelContentStyle {
         offsetDistance={-Math.round(this.labelContentRefElement.getBoundingClientRect().width)}
         offsetSkidding={0}
         label=""
-        // todo: move into css class
-        style={{
-          zIndex: "100"
-        }}
+        class="popover"
       >
         <calcite-panel
           intlClose="Close"

--- a/demo/esri-ds2022/src/components/label/label-content-style/label-content-style.tsx
+++ b/demo/esri-ds2022/src/components/label/label-content-style/label-content-style.tsx
@@ -32,8 +32,8 @@ export class LabelContentStyle {
     this.labelContentStyleChanges.emit();
   };
 
-  colorChange = (event: any): void => {
-    this.labelClass.symbol.color = event.target?.value;
+  colorChange = (event: CustomEvent): void => {
+    this.labelClass.symbol.color = (event.target as any)?.value;
     this.labelContentStyleChanges.emit();
   };
 

--- a/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
+++ b/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
@@ -1,14 +1,4 @@
-import {
-  Component,
-  h,
-  Prop,
-  Event,
-  EventEmitter,
-  State,
-  Element,
-  Listen,
-  VNode
-} from "@stencil/core";
+import { Component, h, Prop, Event, EventEmitter, Element, Listen, VNode } from "@stencil/core";
 // esri jsapi widget: https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-ScaleRangeSlider.html
 import ScaleRangeSlider from "@arcgis/core/widgets/ScaleRangeSlider";
 import { DisplayType } from "../_utils";
@@ -48,10 +38,6 @@ export class LabelContent {
   // emit when main panel should be disabled/enabled
   @Event() disableLabelPanel: EventEmitter;
 
-  // todo: split up into multiple states
-  // Need this to rerender on any change since we are making changes to labelclass object, which will not trigger a rerender.
-  @State() reRender = true;
-
   dropdownElement: HTMLCalciteDropdownElement;
 
   dropdownButton: HTMLCalciteButtonElement;
@@ -80,7 +66,7 @@ export class LabelContent {
           this.labelClass.maxScale = value;
         }
         this.closeLabelPopovers.emit();
-        this.reRender = !this.reRender;
+        this.internalLabelUpdated.emit();
       }
     );
     this.mapViewScaleWatch = this.mapView.watch("scale", () => {
@@ -92,11 +78,6 @@ export class LabelContent {
     this.scaleRangeSlider?.destroy();
     this.scaleRangeSliderWatch?.remove();
     this.mapViewScaleWatch?.remove();
-  }
-
-  // Called after every re-render. Not called on initial draw.
-  componentDidUpdate(): void {
-    this.internalLabelUpdated.emit();
   }
 
   @Listen("closeLabelPopovers", { target: "window" })
@@ -117,7 +98,7 @@ export class LabelContent {
     let selectedItem = this.dropdownElement?.selectedItems?.[0]?.id;
     this.dropdownButton.innerHTML = selectedItem;
     this.labelClass.labelExpressionInfo.expression = `$feature["${selectedItem}"]`;
-    this.reRender = !this.reRender;
+    this.internalLabelUpdated.emit();
   };
 
   openLabelStyle = (): void => {
@@ -127,7 +108,7 @@ export class LabelContent {
       this.labelStyle.labelContentRefElement = this.hostElement;
       this.labelStyle.labelClass = this.labelClass;
       this.labelStyle.addEventListener("labelContentStyleChanges", () => {
-        this.reRender = !this.reRender;
+        this.internalLabelUpdated.emit();
       });
       document.body.appendChild(this.labelStyle);
       this.disableLabelPanel.emit(true);

--- a/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
+++ b/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
@@ -69,9 +69,7 @@ export class LabelContent {
         this.internalLabelUpdated.emit();
       }
     );
-    this.mapViewScaleWatch = this.mapView.watch("scale", () => {
-      this.scaleRangeSlider.renderNow();
-    });
+    this.mapViewScaleWatch = this.mapView.watch("scale", () => this.scaleRangeSlider.renderNow());
   }
 
   disconnectedCallback() {
@@ -90,7 +88,7 @@ export class LabelContent {
   }
 
   getDisplayFieldName(): string {
-    return (this.labelClass as any).getLabelExpressionSingleField();
+    return this.labelClass.getLabelExpressionSingleField();
   }
 
   labelFieldSelection = (): void => {

--- a/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
+++ b/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
@@ -112,6 +112,28 @@ export class LabelContent {
     return (this.labelClass as any).getLabelExpressionSingleField();
   }
 
+  labelFieldSelection = (): void => {
+    this.closeLabelPopovers.emit();
+    let selectedItem = this.dropdownElement?.selectedItems?.[0]?.id;
+    this.dropdownButton.innerHTML = selectedItem;
+    this.labelClass.labelExpressionInfo.expression = `$feature["${selectedItem}"]`;
+    this.reRender = !this.reRender;
+  };
+
+  openLabelStyle = (): void => {
+    this.closeLabelPopovers.emit();
+    if (!this.labelStyle) {
+      this.labelStyle = document.createElement("esri-ds2022-label-content-style");
+      this.labelStyle.labelContentRefElement = this.hostElement;
+      this.labelStyle.labelClass = this.labelClass;
+      this.labelStyle.addEventListener("labelContentStyleChanges", () => {
+        this.reRender = !this.reRender;
+      });
+      document.body.appendChild(this.labelStyle);
+      this.disableLabelPanel.emit(true);
+    }
+  };
+
   render(): VNode {
     // dropdown for list of fields
     const labelField = (
@@ -120,14 +142,7 @@ export class LabelContent {
         <calcite-dropdown
           ref={(el) => (this.dropdownElement = el)}
           maxItems={12}
-          // todo: move into class function
-          onCalciteDropdownSelect={(): void => {
-            this.closeLabelPopovers.emit();
-            let selectedItem = this.dropdownElement?.selectedItems?.[0]?.id;
-            this.dropdownButton.innerHTML = selectedItem;
-            this.labelClass.labelExpressionInfo.expression = `$feature["${selectedItem}"]`;
-            this.reRender = !this.reRender;
-          }}
+          onCalciteDropdownSelect={this.labelFieldSelection}
         >
           <calcite-button
             ref={(el) => (this.dropdownButton = el)}
@@ -168,20 +183,7 @@ export class LabelContent {
           iconEnd="chevronDown"
           alignment="icon-end-space-between"
           width="full"
-          // todo: move into class function
-          onClick={() => {
-            this.closeLabelPopovers.emit();
-            if (!this.labelStyle) {
-              this.labelStyle = document.createElement("esri-ds2022-label-content-style");
-              this.labelStyle.labelContentRefElement = this.hostElement;
-              this.labelStyle.labelClass = this.labelClass;
-              this.labelStyle.addEventListener("labelContentStyleChanges", () => {
-                this.reRender = !this.reRender;
-              });
-              document.body.appendChild(this.labelStyle);
-              this.disableLabelPanel.emit(true);
-            }
-          }}
+          onClick={this.openLabelStyle}
         >
           Cluster label
         </calcite-button>

--- a/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
+++ b/demo/esri-ds2022/src/components/label/label-content/label-content.tsx
@@ -73,6 +73,7 @@ export class LabelContent {
   }
 
   disconnectedCallback() {
+    this.closeLabelPopoversHandler();
     this.scaleRangeSlider?.destroy();
     this.scaleRangeSliderWatch?.remove();
     this.mapViewScaleWatch?.remove();
@@ -81,6 +82,10 @@ export class LabelContent {
   @Listen("closeLabelPopovers", { target: "window" })
   closeLabelPopoversHandler(): void {
     if (this.labelStyle) {
+      this.labelStyle.removeEventListener(
+        "labelContentStyleChanges",
+        this.labelContentStyleChanges
+      );
       document.body.removeChild(this.labelStyle);
       this.labelStyle = null;
     }
@@ -99,15 +104,17 @@ export class LabelContent {
     this.internalLabelUpdated.emit();
   };
 
+  labelContentStyleChanges = (): void => {
+    this.internalLabelUpdated.emit();
+  };
+
   openLabelStyle = (): void => {
     this.closeLabelPopovers.emit();
     if (!this.labelStyle) {
       this.labelStyle = document.createElement("esri-ds2022-label-content-style");
       this.labelStyle.labelContentRefElement = this.hostElement;
       this.labelStyle.labelClass = this.labelClass;
-      this.labelStyle.addEventListener("labelContentStyleChanges", () => {
-        this.internalLabelUpdated.emit();
-      });
+      this.labelStyle.addEventListener("labelContentStyleChanges", this.labelContentStyleChanges);
       document.body.appendChild(this.labelStyle);
       this.disableLabelPanel.emit(true);
     }

--- a/demo/esri-ds2022/src/components/label/label.tsx
+++ b/demo/esri-ds2022/src/components/label/label.tsx
@@ -44,9 +44,11 @@ export class Label {
    */
   @Event() closeLabelPopovers: EventEmitter;
 
-  // todo: move these to separate state properties
-  // Need this to rerender on any change since we are making changes to label object, which will not trigger a rerender.
-  @State() reRender: boolean;
+  @State() hasLabelEnabled: boolean = null;
+
+  @State() addLabelingInfo: boolean = false;
+
+  @State() deleteLabelContent = false;
 
   labelingInfo: __esri.LabelClass[];
 
@@ -147,7 +149,7 @@ export class Label {
       } else {
         this.labelingInfo = [labelClass];
       }
-      this.reRender = !this.reRender;
+      this.addLabelingInfo = !this.addLabelingInfo;
     });
     return calciteFab;
   }
@@ -161,7 +163,7 @@ export class Label {
       this.layer.labelsVisible = checked;
     }
     this.addLabelBtn.hidden = !checked;
-    this.reRender = !this.reRender;
+    this.hasLabelEnabled = checked;
   };
 
   labelContentDeleted(labelClass: __esri.LabelClass): void {
@@ -169,7 +171,7 @@ export class Label {
     this.labelingInfo = this.labelingInfo.filter(
       (label: __esri.LabelClass) => label !== labelClass
     );
-    this.reRender = !this.reRender;
+    this.deleteLabelContent = !this.deleteLabelContent;
   }
 
   // rendor methods

--- a/demo/esri-ds2022/src/typings/arcgis-js-api-extensions.ts
+++ b/demo/esri-ds2022/src/typings/arcgis-js-api-extensions.ts
@@ -1,0 +1,6 @@
+/* Note: using `.d.ts` file extension will exclude it from the output build */
+declare namespace __esri {
+  interface LabelClass {
+    getLabelExpressionSingleField(): string;
+  }
+}


### PR DESCRIPTION
slider did not work correctly in connectedcomponent.

display type is internal since don't want external clients accessing them directly.

https://github.com/driskull/2022-ds-building-geospatial-web-components/pull/4/files#diff-344febb34f44b3fa5d8b967ddee98a97b7bb32e8302f9ff09b5b619d57f2f7ffL60: dont expect this to change after initial setup